### PR TITLE
Pin sphinx to 4.0.2 for `nbsphinx` compatability

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,9 +6,11 @@ dependencies:
 
   # Base depends
   - python
+  - pip
   - setuptools
 
   # Sphinx specific
+  - sphinx ==4.0.2
   - nbsphinx
   - nbsphinx-link
   - sphinx_rtd_theme


### PR DESCRIPTION
## Description

This PR pins to `sphinx ==4.0.2` to resolve `nbsphinx` compatability issues (see https://github.com/spatialaudio/nbsphinx/issues/584)

## Status
- [X] Ready to go