### PR TITLE
Fix #118

### DIFF
--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -61,7 +61,7 @@ class Fragment(BaseModel):
     @property
     def molecule(self) -> Molecule:
         """The fragment represented as an OpenFF molecule object."""
-        return Molecule.from_smiles(self.smiles)
+        return Molecule.from_smiles(self.smiles, allow_undefined_stereo=True)
 
 
 class FragmentationResult(BaseModel):
@@ -217,7 +217,7 @@ class Fragmenter(BaseModel, abc.ABC):
     @classmethod
     def _fix_stereo(
         cls, fragment: Molecule, parent_stereo: Stereochemistries
-    ) -> Molecule:
+    ) -> Tuple[Molecule, bool]:
         """Flip all stereocenters and find the stereoisomer that matches the parent
 
         Parameters
@@ -229,7 +229,7 @@ class Fragmenter(BaseModel, abc.ABC):
 
         Returns
         -------
-            A fragment with the same stereochemistry as parent molecule
+            A fragment with the same stereochemistry as parent molecule if possible else a fragment and a bool to indicate it was note possible.
         """
 
         for stereoisomer in _enumerate_stereoisomers(fragment, 200, True):
@@ -237,11 +237,9 @@ class Fragmenter(BaseModel, abc.ABC):
             if not cls._check_stereo(stereoisomer, parent_stereo):
                 continue
 
-            return stereoisomer
+            return stereoisomer, True
 
-        raise RuntimeError(
-            f"The stereochemistry of {fragment.to_smiles()} could not be fixed."
-        )
+        return fragment, False
 
     @classmethod
     def _find_functional_groups(
@@ -370,7 +368,7 @@ class Fragmenter(BaseModel, abc.ABC):
         parent_stereo: Stereochemistries,
         atoms: Set[int],
         bonds: Set[BondTuple],
-    ) -> Molecule:
+    ) -> Tuple[Molecule, bool]:
         """Extracts a subset of a molecule based on a set of atom and bond indices.
 
         Parameters
@@ -387,15 +385,17 @@ class Fragmenter(BaseModel, abc.ABC):
 
         Returns
         -------
-            The subset molecule.
+            The subset molecule and a flag to indicate if the stereo is correct or not.
         """
 
         fragment = extract_fragment(parent, atoms, bonds)
 
         if not cls._check_stereo(fragment, parent_stereo):
-            fragment = cls._fix_stereo(fragment, parent_stereo)
+            fragment, correct_stereo = cls._fix_stereo(fragment, parent_stereo)
+        else:
+            correct_stereo = True
 
-        return fragment
+        return fragment, correct_stereo
 
     @classmethod
     def _get_torsion_quartet(
@@ -1186,13 +1186,17 @@ class WBOFragmenter(Fragmenter):
         if cap:
             atoms, bonds = cls._cap_open_valence(parent, parent_groups, atoms, bonds)
 
-        fragment = cls._atom_bond_set_to_mol(parent, parent_stereo, atoms, bonds)
+        fragment, correct_stereo = cls._atom_bond_set_to_mol(
+            parent, parent_stereo, atoms, bonds
+        )
 
         wbo_difference = cls._compare_wbo(fragment, bond_tuple, parent_wbo, **kwargs)
+        if not correct_stereo:
+            wbo_difference = 1.0
 
         while fragment is not None and wbo_difference > threshold:
 
-            fragment = cls._add_next_substituent(
+            fragment, correct_stereo = cls._add_next_substituent(
                 parent,
                 parent_stereo,
                 parent_groups,
@@ -1209,13 +1213,15 @@ class WBOFragmenter(Fragmenter):
             wbo_difference = cls._compare_wbo(
                 fragment, bond_tuple, parent_wbo, **kwargs
             )
+            if not correct_stereo:
+                wbo_difference = 1.0
 
         # A work around for a known bug where if stereochemistry changes or gets removed,
         # the WBOs can change more than the threshold (this will sometimes happen if a
         # very small threshold is chosen) and even the parent will have a WBO difference
         # greater than the threshold. In this case, return the molecule
         if fragment is None:
-            fragment = cls._atom_bond_set_to_mol(parent, parent_stereo, atoms, bonds)
+            fragment, _ = cls._atom_bond_set_to_mol(parent, parent_stereo, atoms, bonds)
 
         return fragment
 
@@ -1357,7 +1363,7 @@ class WBOFragmenter(Fragmenter):
         bonds: Set[BondTuple],
         target_bond: BondTuple,
         heuristic: Heuristic = "path_length",
-    ) -> Optional[Molecule]:
+    ) -> Tuple[Optional[Molecule], bool]:
         """Expand the fragment to include the next set of substituents / ring systems.
 
         Parameters
@@ -1463,7 +1469,7 @@ class PfizerFragmenter(Fragmenter):
 
             atoms, bonds = self._cap_open_valence(parent, parent_groups, atoms, bonds)
 
-            fragments[bond] = self._atom_bond_set_to_mol(
+            fragments[bond], _ = self._atom_bond_set_to_mol(
                 parent, parent_stereo, atoms, bonds
             )
         return FragmentationResult(

--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1415,7 +1415,7 @@ class WBOFragmenter(Fragmenter):
             )
 
         if neighbour_atom_and_bond is None:
-            return None
+            return None, False
 
         neighbour_atom, neighbour_bond = neighbour_atom_and_bond
 

--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1201,7 +1201,7 @@ class WBOFragmenter(Fragmenter):
 
         while fragment is not None and wbo_difference > threshold:
 
-            fragment, correct_stereo = cls._add_next_substituent(
+            fragment, has_new_stereocenter = cls._add_next_substituent(
                 parent,
                 parent_stereo,
                 parent_groups,

--- a/openff/fragmenter/tests/test_fragmenter.py
+++ b/openff/fragmenter/tests/test_fragmenter.py
@@ -99,7 +99,7 @@ def test_fix_stereo(smiles, fragment_smiles):
     parent_stereo = Fragmenter._find_stereo(smiles_to_molecule(smiles, True))
 
     fragment = smiles_to_molecule(fragment_smiles, add_atom_map=True)
-    fixed, _ = Fragmenter._fix_stereo(fragment, parent_stereo)
+    fixed = Fragmenter._fix_stereo(fragment, parent_stereo)
 
     assert Fragmenter._check_stereo(fixed, parent_stereo) is True
 

--- a/openff/fragmenter/tests/test_fragmenter.py
+++ b/openff/fragmenter/tests/test_fragmenter.py
@@ -99,7 +99,7 @@ def test_fix_stereo(smiles, fragment_smiles):
     parent_stereo = Fragmenter._find_stereo(smiles_to_molecule(smiles, True))
 
     fragment = smiles_to_molecule(fragment_smiles, add_atom_map=True)
-    fixed = Fragmenter._fix_stereo(fragment, parent_stereo)
+    fixed, _ = Fragmenter._fix_stereo(fragment, parent_stereo)
 
     assert Fragmenter._check_stereo(fixed, parent_stereo) is True
 
@@ -207,7 +207,9 @@ def test_atom_bond_set_to_mol(abemaciclib):
         and get_map_index(molecule, bond.atom2_index) in atoms
     }
 
-    fragment = Fragmenter._atom_bond_set_to_mol(molecule, {}, atoms=atoms, bonds=bonds)
+    fragment, _ = Fragmenter._atom_bond_set_to_mol(
+        molecule, {}, atoms=atoms, bonds=bonds
+    )
 
     for bond in fragment.bonds:
 
@@ -600,7 +602,7 @@ def test_add_substituent():
         if bond.atom1.atomic_number != 1 and bond.atom2.atomic_number != 1
     )
 
-    fragment = WBOFragmenter._add_next_substituent(
+    fragment, _ = WBOFragmenter._add_next_substituent(
         result.parent_molecule, {}, {}, {}, atoms, bonds, target_bond=(3, 5)
     )
 

--- a/openff/fragmenter/tests/test_regression.py
+++ b/openff/fragmenter/tests/test_regression.py
@@ -43,3 +43,15 @@ def test_wbo_regression(parent, fragments):
     for fragment in fragments:
         fragment_mol = Molecule.from_mapped_smiles(fragment)
         assert fragment_mol in result_fragments
+
+
+def test_stereo_error():
+    """
+    Make sure the molecule can be fragmented, before PR123 this molecule would result in a runtime error as new
+    stereocenters would be created.
+    """
+    parent = Molecule.from_smiles(
+        "[H][O][C]([H])([H])[C]([H])([H])[C]([H])([N]([H])[C]1=[N][C]([H])=[C]2[C](=[N]1)[N]([C]([H])([H])[H])[C](=[O])[C]([O][C]1=[C]([F])[C]([H])=[C]([F])[C]([H])=[C]1[H])=[C]2[H])[C]([H])([H])[C]([H])([H])[O][H]"
+    )
+    engine = WBOFragmenter()
+    _ = engine.fragment(parent)


### PR DESCRIPTION
## Description
Fixes #118 by making fragmeter continue to grow the fragment until the sterochemistry can be fixed. The error is normally caused by new stereocenters being formed whereby enumerating the stereochemistry can not fix the issue, instead we continue to grow the fragment to remove the new centre until we return the parent molecule.

I can confirm this now works for the example I posted in the issue, `[H][O][C]([H])([H])[C]([H])([H])[C]([H])([N]([H])[C]1=[N][C]([H])=[C]2[C](=[N]1)[N]([C]([H])([H])[H])[C](=[O])[C]([O][C]1=[C]([F])[C]([H])=[C]([F])[C]([H])=[C]1[H])=[C]2[H])[C]([H])([H])[C]([H])([H])[O][H]`

![image](https://user-images.githubusercontent.com/30259414/129015266-a69e75ff-ae75-473b-8627-4a9f56cfb8ab.png)


## Status
- [x] Ready to go