### PR TITLE
Use single conformer WBOs if ELF fails

### DIFF
--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1009,9 +1009,14 @@ class WBOFragmenter(Fragmenter):
                 "WBOs can currently only be computed using 'am1-wiberg-elf10'."
             )
 
-        molecule = assign_elf10_am1_bond_orders(
-            molecule, self.wbo_options.max_conformers, self.wbo_options.rms_threshold
-        )
+        try:
+            molecule = assign_elf10_am1_bond_orders(
+                molecule, self.wbo_options.max_conformers, self.wbo_options.rms_threshold
+            )
+        except RuntimeError:
+            logger.warning("There was a problem with ELF conformer selection. Computing "
+                           "fractional bond orders using a single conformer instead.")
+            molecule.assign_fractional_bond_orders(bond_order_model='AM1-Wiberg')
 
         rotatable_bonds = self.find_rotatable_bonds(molecule, target_bond_smarts)
         wbo_rotor_bonds = self._get_rotor_wbo(molecule, rotatable_bonds)


### PR DESCRIPTION
## Description
A user was getting the following error in BespokeFit, which we ultimately tracked down to OpenEye [pruning all conformers](https://github.com/openforcefield/openff-toolkit/blob/3681e1361ae4d54dc57036b58c543653fa454ccb/openff/toolkit/utils/openeye_wrapper.py#L1757-L1779) since they had trans-COOHs.

The full traceback is

```
[2021-11-12 11:09:48,931: INFO/Process-3] Task openff.bespokefit.executor.services.fragmenter.worker.fragment[1376fa85-4036-4785-8c3a-32311e167a0f] received
[2021-11-12 11:09:49,575: ERROR/ForkPoolWorker-1] Task openff.bespokefit.executor.services.fragmenter.worker.fragment[1376fa85-4036-4785-8c3a-32311e167a0f] raised unexpected: RuntimeError('\n')
Traceback (most recent call last):
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/celery/app/trace.py", line 450, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/celery/app/trace.py", line 731, in __protected_call__
    return self.run(*args, **kwargs)
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/bespokefit/executor/services/fragmenter/worker.py", line 26, in fragment
    return fragmenter.fragment(molecule, target_bond_smarts=target_bond_smarts).json()
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/fragmenter/fragment.py", line 916, in fragment
    result = self._fragment(molecule, target_bond_smarts)
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/fragmenter/fragment.py", line 1012, in _fragment
    molecule = assign_elf10_am1_bond_orders(
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/fragmenter/chemi.py", line 42, in assign_elf10_am1_bond_orders
    molecule.apply_elf_conformer_selection()
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/toolkit/topology/molecule.py", line 3361, in apply_elf_conformer_selection
    toolkit_registry.call(
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/toolkit/utils/toolkit_registry.py", line 366, in call
    raise e
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/toolkit/utils/toolkit_registry.py", line 362, in call
    return method(*args, **kwargs)
  File "/Users/daniellebergaziin/anaconda/envs/bespoke/lib/python3.9/site-packages/openff/toolkit/utils/openeye_wrapper.py", line 1776, in apply_elf_conformer_selection
    raise RuntimeError("\n" + output_string)
RuntimeError:
```

The toolkit error needs to be fixed to be more informative here, but more immediately, I'd like to harden this stack since we'll be getting more traffic through bespokefit soon.

To that end, the right place for a fix seemed to be in fragmenter. If funny things happen with trans-COOHs, I think users would prefer to get a suboptimally fragmented molecule instead of an full stop.

@SimonBoothroyd and @jthorton - Does this seem like a good decision to you? I can proceed with polishing this PR if so, but I didn't want to go too far in case we want to solve this somewhere else in the stack. 