### PR TITLE
Fix test_depiction now that toolkit doesn't handle radicals

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     branches:
-      - "master"
+      - "main"
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: lint
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     branches:
-      - "master"
+      - "main"
 
 jobs:
 

--- a/openff/fragmenter/tests/test_chemi.py
+++ b/openff/fragmenter/tests/test_chemi.py
@@ -236,7 +236,9 @@ def test_extract_fragment_bonds_in_atoms():
 @using_openeye
 def test_extract_fragment_disconnected_fragment_warning():
 
-    molecule = Molecule.from_smiles("[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])")
+    molecule = Molecule.from_smiles(
+        "[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])"
+    )
 
     with pytest.raises(AssertionError, match="An atom that is not bonded"):
         extract_fragment(molecule, {1, 2}, set())

--- a/openff/fragmenter/tests/test_chemi.py
+++ b/openff/fragmenter/tests/test_chemi.py
@@ -236,7 +236,7 @@ def test_extract_fragment_bonds_in_atoms():
 @using_openeye
 def test_extract_fragment_disconnected_fragment_warning():
 
-    molecule = Molecule.from_smiles("[C:1][C:2]")
+    molecule = Molecule.from_smiles("[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])")
 
     with pytest.raises(AssertionError, match="An atom that is not bonded"):
         extract_fragment(molecule, {1, 2}, set())

--- a/openff/fragmenter/tests/test_depiction.py
+++ b/openff/fragmenter/tests/test_depiction.py
@@ -17,7 +17,11 @@ from openff.toolkit.topology import Molecule
 def test_xx_render_parent(draw_function):
 
     try:
-        svg_contents = draw_function(Molecule.from_smiles("[C:1][C:2][C:3][C:4]"))
+        svg_contents = draw_function(
+            Molecule.from_smiles(
+                "[C:1]([H:5])([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])([H:14])"
+            )
+        )
     except ModuleNotFoundError as e:
         pytest.skip(str(e))
 
@@ -31,8 +35,12 @@ def test_xx_render_fragment(draw_function):
     try:
 
         svg_contents = draw_function(
-            Molecule.from_smiles("[C:1][C:2][C:3][C:4]"),
-            Molecule.from_smiles("[C:1][C:2]"),
+            Molecule.from_smiles(
+                "[C:1]([H:5])([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])([H:14])"
+            ),
+            Molecule.from_smiles(
+                "[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])"
+            ),
             (1, 2),
         )
 
@@ -48,8 +56,14 @@ def test_depict_fragments(tmpdir):
     output_file = os.path.join(tmpdir, "report.html")
 
     depict_fragments(
-        Molecule.from_smiles("[C:1][C:2][C:3][C:4]"),
-        {(1, 2): Molecule.from_smiles("[C:1][C:2]")},
+        Molecule.from_smiles(
+            "[C:1]([H:5])([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])([H:14])"
+        ),
+        {
+            (1, 2): Molecule.from_smiles(
+                "[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])"
+            )
+        },
         output_file,
     )
 
@@ -66,8 +80,13 @@ def test_depict_fragmentation_result(tmpdir):
 
     depict_fragmentation_result(
         FragmentationResult(
-            parent_smiles="[C:1][C:2][C:3][C:4]",
-            fragments=[Fragment(smiles="[C:1][C:2]", bond_indices=(1, 2))],
+            parent_smiles="[C:1]([H:5])([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[C:4]([H:12])([H:13])([H:14])",
+            fragments=[
+                Fragment(
+                    smiles="[C:1]([H:3])([H:4])([H:5])[C:2]([H:6])([H:7])([H:8])",
+                    bond_indices=(1, 2),
+                )
+            ],
             provenance={},
         ),
         output_file,


### PR DESCRIPTION
## Description
The tests in `test_depiction` used mapped SMILES to define test molecules. However, molecules created using mapped SMILES are expected to have explicit Hs, which these test SMILES didn't. This PR makes the Hs explicit on these input SMILES.

## Todos

  - [x] Fix tests
  - [x] `black`

## Status
- [x] Ready to go