### PR TITLE
Add link to OpenFF install guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,10 @@ intersphinx_mapping = {
         "https://open-forcefield-toolkit.readthedocs.io/en/latest/",
         None,
     ),
+    "openff.docs": (
+        "https://docs.openforcefield.org/en/latest/",
+        None,
+    ),
 }
 
 # Set up mathjax.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,6 +10,8 @@ The recommended way to install ``openff-fragmenter`` is via the ``conda`` packag
 
     conda install -c conda-forge openff-fragmenter
 
+If you do not have Conda installed, see the `OpenFF installation guide <openff.docs:install>`_.
+
 If you have access to the OpenEye toolkits (namely ``oechem``, ``oequacpac`` and ``oeomega``) we recommend installing
 these also as these can speed up fragmentation times significantly:
 


### PR DESCRIPTION
Adds a link to the [ecosystem install guide](https://docs.openforcefield.org/en/latest/install.html) to the project install guide

## Status
- [x] Ready to go