### PR TITLE
Fix 177

### DIFF
--- a/openff/fragmenter/_tests/test_fragmenter.py
+++ b/openff/fragmenter/_tests/test_fragmenter.py
@@ -584,6 +584,16 @@ def test_add_substituent():
     assert fragment.to_smiles(mapped=False, explicit_hydrogens=False) == "CCCCCC"
 
 
+def test_issue_177():
+    """
+    There was an where the path search gets tripped up when there are two paths
+    of equal length leading to a 3-membered ring. This test ensures Fragmenter
+    runs on a minimal reproducing example of this problem.
+    More info at https://github.com/openforcefield/openff-fragmenter/issues/177
+    """
+    WBOFragmenter().fragment(Molecule.from_smiles("C1CC1[C@H]2C[C@H]3C[C@H]3C2"))
+
+
 @pytest.mark.parametrize("input_smiles, n_output", [("CCCCCCC", 4)])
 def test_pfizer_fragmenter(input_smiles, n_output):
     result = PfizerFragmenter().fragment(Molecule.from_smiles(input_smiles))

--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1246,7 +1246,7 @@ class WBOFragmenter(Fragmenter):
 
         target_indices = [get_atom_index(molecule, atom) for atom in target_bond]
 
-        path_lengths_1, path_lengths_2 = zip(
+        path_lengths = list(zip(
             *(
                 (
                     networkx.shortest_path_length(
@@ -1256,7 +1256,7 @@ class WBOFragmenter(Fragmenter):
                 )
                 for atom_index, neighbour_index in atoms_to_add
             )
-        )
+        ))
 
         if len(path_lengths) == 0:
             return None

--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1246,17 +1246,19 @@ class WBOFragmenter(Fragmenter):
 
         target_indices = [get_atom_index(molecule, atom) for atom in target_bond]
 
-        path_lengths = list(zip(
-            *(
-                (
-                    networkx.shortest_path_length(
-                        nx_molecule, target_index, neighbour_index
+        path_lengths = list(
+            zip(
+                *(
+                    (
+                        networkx.shortest_path_length(
+                            nx_molecule, target_index, neighbour_index
+                        )
+                        for target_index in target_indices
                     )
-                    for target_index in target_indices
+                    for atom_index, neighbour_index in atoms_to_add
                 )
-                for atom_index, neighbour_index in atoms_to_add
             )
-        ))
+        )
 
         if len(path_lengths) == 0:
             return None

--- a/openff/fragmenter/fragment.py
+++ b/openff/fragmenter/fragment.py
@@ -1258,8 +1258,9 @@ class WBOFragmenter(Fragmenter):
             )
         )
 
-        if len(path_lengths_1) == 0 and len(path_lengths_2) == 0:
+        if len(path_lengths) == 0:
             return None
+        path_lengths_1, path_lengths_2 = path_lengths
 
         reverse = False
 


### PR DESCRIPTION
## Description

There's an error raised when the shortest-path algorithm has two equal-length ways to come up on a fused 3-membered ring. There was some code in fragmenter that may have been intended to catch this case, but I believe it is unreachable because the error it is attempting to prevent raises before the error-prevention code is reached. CodeCov seems to agree with me, as the check for length 0 is never reached in any tests (the error that is raised first is that `path_lengths_1, path_lengths_2 = zip(...)` raises immediately if there are no items in the output of `zip`). 
 
<img width="840" alt="Screenshot 2024-06-04 at 4 16 07 PM" src="https://github.com/openforcefield/openff-fragmenter/assets/16329175/7336c7bc-b4ab-4d15-af9c-d75df5dd0edc">


## Todos
  - [x] Fixes #177
  - [x] Adds tests

## Status
- [x] Ready to go