### PR TITLE
Avoid duplicating boilerplate `--runslow` argument

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,14 @@ jobs:
       run: |
         python -m pip install -e .
 
-    - name: Run Tests
+    - name: Run unit tests
       run: |
-        pytest -v --cov=openff --cov-report=xml --color=yes openff/fragmenter/_tests/ -nauto
+        pytest -v --cov=openff --cov-report=xml --color=yes openff/fragmenter/_tests/ -nlogical
+
+    - name: Run slow tests
+      run: |
+        pytest -v --cov=openff --cov-report=xml --color=yes openff/fragmenter/_tests/ -nlogical \
+          -m "fragmenter_slow"
 
     - name: CodeCov
       uses: codecov/codecov-action@v4

--- a/openff/fragmenter/_tests/conftest.py
+++ b/openff/fragmenter/_tests/conftest.py
@@ -5,24 +5,6 @@ from openff.toolkit.topology import Molecule
 from openff.toolkit.utils.exceptions import AtomMappingWarning
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests"
-    )
-
-
-def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
-
 
 @pytest.fixture()
 def potanib() -> Molecule:

--- a/openff/fragmenter/_tests/conftest.py
+++ b/openff/fragmenter/_tests/conftest.py
@@ -5,7 +5,6 @@ from openff.toolkit.topology import Molecule
 from openff.toolkit.utils.exceptions import AtomMappingWarning
 
 
-
 @pytest.fixture()
 def potanib() -> Molecule:
     with warnings.catch_warnings():

--- a/openff/fragmenter/_tests/test_regression.py
+++ b/openff/fragmenter/_tests/test_regression.py
@@ -33,7 +33,7 @@ from openff.toolkit.topology import Molecule
         ),
     ],
 )
-@pytest.mark.slow
+@pytest.mark.fragmenter_slow
 def test_wbo_regression(parent, fragments):
     """Make sure we can produce the expected fragments using both openeye and AT+RDKIT."""
     parent = Molecule.from_mapped_smiles(parent)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    fragmenter_slow: marks tests as slow tests (deselect with '-m "not framenter_slow"')
+addopts = -m "not fragmenter_slow"


### PR DESCRIPTION
## Description
Short story: our projects copy-past [this](https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option) setup, which does not work when running multiple repos' tests at once. Simply renaming a few should avoid this conflict.

The behavior is conceptually un-changed; slow tests are not run by default but can be turned on with command-line flags.